### PR TITLE
Commented code that adds endpoint for self telemetry for OpAmp server.

### DIFF
--- a/internal/examples/server/data/agent.go
+++ b/internal/examples/server/data/agent.go
@@ -188,7 +188,9 @@ func (agent *Agent) processStatusUpdate(
 		configChanged = agent.calcRemoteConfig()
 
 		// And set connection settings that are appropriate for the Agent description.
-		agent.calcConnectionSettings(response)
+		// TODO: Uncomment this once we set the right configurations for metrics.
+		// Uncommented as of 07/30/2022 to stop connection refused error.
+		//agent.calcConnectionSettings(response)
 	}
 
 	// If remote config is changed and different from what the Agent has then


### PR DESCRIPTION
Remove self telemetry code

This PR comments the self telemetry code that results in the following output:
"2022/07/11 09:32:01 Post "http://localhost:4318/v1/metrics": dial tcp [::1]:4318: connect: connection refused"